### PR TITLE
add alternative impl

### DIFF
--- a/ecs/rust/src/alt.rs
+++ b/ecs/rust/src/alt.rs
@@ -1,0 +1,168 @@
+use rand::prelude::*;
+use std::ops::{AddAssign, Mul, Sub};
+use std::time::Instant;
+
+use crate::{ITERATIONS, MAX_COLLIDER, MAX_POSITION, MAX_SPEED};
+
+#[derive(Copy, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl Point {
+    /// Returns a new point where each value is uniformly random over the interval [0..max]
+    fn rand(max: f64) -> Point {
+        let mut rng = rand::thread_rng();
+        Point {
+            x: rng.gen::<f64>() * max,
+            y: rng.gen::<f64>() * max,
+        }
+    }
+
+    /// Return the square of the magnitude of the point
+    fn mag_sq(&self) -> f64 {
+        self.x * self.x + self.y * self.y
+    }
+
+    /// Returns the square of the distance to another point
+    fn dist_sq(&self, other: &Point) -> f64 {
+        (*self - *other).mag_sq()
+    }
+}
+
+impl Sub for Point {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Point {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+impl AddAssign for Point {
+    fn add_assign(&mut self, rhs: Self) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+    }
+}
+
+impl Mul<f64> for Point {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Point {
+            x: self.x * rhs,
+            y: self.y * rhs,
+        }
+    }
+}
+
+struct Entity {
+    id: usize,
+    /// Counter for the number of collisions
+    collisions: usize,
+    /// Location of the entity
+    pos: Point,
+    /// Velocity of the entitiy
+    vel: Point,
+    radius: f64,
+}
+
+impl Entity {
+    fn rand(id: usize) -> Entity {
+        let mut rng = rand::thread_rng();
+        Entity {
+            id,
+            collisions: 0,
+            pos: Point::rand(MAX_POSITION),
+            vel: Point::rand(MAX_SPEED),
+            radius: rng.gen::<f64>() * MAX_COLLIDER,
+        }
+    }
+
+    /// Apply velocity to the entity, updating position
+    /// `dt` is the timestep
+    fn apply_v(&mut self, dt: f64) {
+        self.pos += self.vel * dt
+    }
+
+    /// Check for and process collisions with the outer bounding box, defined as 0..MAX_POSITION
+    fn collide_bb(&mut self) {
+        if !(0.0..MAX_POSITION).contains(&self.pos.x) {
+            self.vel.x *= -1.0;
+        }
+        if !(0.0..MAX_POSITION).contains(&self.pos.y) {
+            self.vel.y *= -1.0;
+        }
+    }
+
+    /// Returns the square of the distance between two entities
+    fn dist_sq(&self, other: &Entity) -> f64 {
+        self.pos.dist_sq(&other.pos)
+    }
+
+    /// Update position, applying the velocity and then performing boundary checks
+    /// `dt` is the timestamp
+    fn update_pos(&mut self, dt: f64) {
+        self.apply_v(dt);
+        self.collide_bb();
+    }
+
+    /// Tests if two entities are colliding
+    fn colliding(&self, other: &Entity) -> bool {
+        let dr = (self.radius + other.radius).powi(2);
+        self.dist_sq(other) > dr
+    }
+
+    fn inc_collision(&mut self, collision_limit: usize, death_count: &mut usize) {
+        self.collisions += 1;
+        if self.collisions > collision_limit {
+            // Removed because the reference impl does not have this, but it seems like
+            // it make sense
+            // self.collision = 0;
+            *death_count += 1;
+        }
+    }
+
+    /// Process a possible collision between two entities
+    /// If the two entities are not in contact, nothing changes
+    fn collide(&mut self, other: &mut Entity, collision_limit: usize, death_count: &mut usize) {
+        if self.colliding(other) {
+            self.inc_collision(collision_limit, death_count);
+            other.inc_collision(collision_limit, death_count);
+        }
+    }
+}
+
+pub fn native(size: usize, collision_limit: usize) {
+    let mut entities = Vec::with_capacity(size);
+
+    for i in 0..size {
+        entities.push(Entity::rand(i + 2));
+    }
+
+    let fixed_dt = 0.015;
+    let mut death_count = 0;
+
+    for step in 0..ITERATIONS {
+        let start = Instant::now();
+
+        entities
+            .iter_mut()
+            .for_each(|entity| entity.update_pos(fixed_dt));
+
+        for i in 0..size - 1 {
+            let (left, right) = entities.split_at_mut(i + 1);
+            let e0 = &mut left[i];
+            for e1 in right {
+                e0.collide(e1, collision_limit, &mut death_count);
+            }
+        }
+
+        let elapsed = start.elapsed();
+        println!("{step}: {:?}", (elapsed.as_micros() as f64) / 1000000.0);
+    }
+}

--- a/ecs/rust/src/main.rs
+++ b/ecs/rust/src/main.rs
@@ -1,33 +1,37 @@
 use bevy_ecs::prelude::*;
 use rand::prelude::*;
-use std::time::{Instant};
 use std::env;
+use std::time::Instant;
 
-#[derive(Component)]
-#[derive(Debug)]
-struct Position { x: f64, y: f64 }
+mod alt;
 
-#[derive(Component)]
-#[derive(Debug)]
-struct Velocity { x: f64, y: f64 }
+#[derive(Component, Debug)]
+struct Position {
+    x: f64,
+    y: f64,
+}
 
-#[derive(Component)]
-#[derive(Debug)]
+#[derive(Component, Debug)]
+struct Velocity {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Component, Debug)]
 struct Collider {
     radius: f64,
 }
 
-#[derive(Component)]
-#[derive(Debug)]
+#[derive(Component, Debug)]
 struct Count {
     count: i32,
 }
 
-const ITERATIONS : i64 = 50;
+const ITERATIONS: i64 = 50;
 
-const MAX_POSITION : f64 = 100.0;
-const MAX_SPEED : f64 = 10.0;
-const MAX_COLLIDER : f64 = 1.0;
+const MAX_POSITION: f64 = 100.0;
+const MAX_SPEED: f64 = 10.0;
+const MAX_COLLIDER: f64 = 1.0;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -42,41 +46,53 @@ fn main() {
         native(size, collision_limit);
     } else if program == "nativeSplit" {
         native_split(size, collision_limit);
+    } else if program == "other" {
+        alt::native(size as usize, collision_limit as usize);
     }
 }
 
-fn bevy(size :i32, collision_limit :i32) {
-//    println!("starting");
+fn bevy(size: i32, collision_limit: i32) {
+    //    println!("starting");
 
     let mut world = World::default();
 
     // For loop
     let mut rng = rand::thread_rng();
     for _i in 0..size {
-        world.spawn()
-            .insert(Position{ x: MAX_POSITION * rng.gen::<f64>(), y: MAX_POSITION * rng.gen::<f64>() })
-            .insert(Velocity{ x: MAX_SPEED * rng.gen::<f64>(), y: MAX_SPEED * rng.gen::<f64>() })
-            .insert(Collider{ radius: MAX_COLLIDER * rng.gen::<f64>() })
-            .insert(Count{ count: 0 });
+        world
+            .spawn()
+            .insert(Position {
+                x: MAX_POSITION * rng.gen::<f64>(),
+                y: MAX_POSITION * rng.gen::<f64>(),
+            })
+            .insert(Velocity {
+                x: MAX_SPEED * rng.gen::<f64>(),
+                y: MAX_SPEED * rng.gen::<f64>(),
+            })
+            .insert(Collider {
+                radius: MAX_COLLIDER * rng.gen::<f64>(),
+            })
+            .insert(Count { count: 0 });
     }
 
     let mut schedule = Schedule::default();
 
     // Stages
-    schedule.add_stage("update", SystemStage::single_threaded()
-                       .with_system(update_position)
+    schedule.add_stage(
+        "update",
+        SystemStage::single_threaded().with_system(update_position),
     );
 
-    let collision = move | commands: Commands,
-                 query: Query<(Entity, &Position, &Collider, &mut Count)>,
-                 query2: Query<(Entity, &Position, &Collider)> | {
+    let collision = move |commands: Commands,
+                          query: Query<(Entity, &Position, &Collider, &mut Count)>,
+                          query2: Query<(Entity, &Position, &Collider)>| {
         check_collision(commands, query, query2, collision_limit);
     };
-    schedule.add_stage("collision", SystemStage::single_threaded()
-                       .with_system(collision)
-
+    schedule.add_stage(
+        "collision",
+        SystemStage::single_threaded().with_system(collision),
     );
-/*    schedule.add_stage("print", SystemStage::single_threaded()
+    /*    schedule.add_stage("print", SystemStage::single_threaded()
                        .with_system(print_count)
     );*/
 
@@ -88,12 +104,13 @@ fn bevy(size :i32, collision_limit :i32) {
     }
 }
 
-
 // https://bevy-cheatbook.github.io/programming/paramset.html
-fn check_collision(mut commands: Commands,
-                   mut query: Query<(Entity, &Position, &Collider, &mut Count)>,
-                   query2: Query<(Entity, &Position, &Collider)>,
-                   collision_limit : i32) {
+fn check_collision(
+    mut commands: Commands,
+    mut query: Query<(Entity, &Position, &Collider, &mut Count)>,
+    query2: Query<(Entity, &Position, &Collider)>,
+    collision_limit: i32,
+) {
     let mut death_count = 0;
 
     for (ent1, position, collider, mut count) in query.iter_mut() {
@@ -122,21 +139,30 @@ fn check_collision(mut commands: Commands,
         }
     }
 
-//    println!("DeathCount: {}", death_count);
+    //    println!("DeathCount: {}", death_count);
     let mut rng = rand::thread_rng();
     for _i in 0..death_count {
-        commands.spawn()
-            .insert(Position{ x: MAX_POSITION * rng.gen::<f64>(), y: MAX_POSITION * rng.gen::<f64>() })
-            .insert(Velocity{ x: MAX_SPEED * rng.gen::<f64>(), y: MAX_SPEED * rng.gen::<f64>() })
-            .insert(Collider{ radius: MAX_COLLIDER * rng.gen::<f64>() })
-            .insert(Count{ count: 0 });
+        commands
+            .spawn()
+            .insert(Position {
+                x: MAX_POSITION * rng.gen::<f64>(),
+                y: MAX_POSITION * rng.gen::<f64>(),
+            })
+            .insert(Velocity {
+                x: MAX_SPEED * rng.gen::<f64>(),
+                y: MAX_SPEED * rng.gen::<f64>(),
+            })
+            .insert(Collider {
+                radius: MAX_COLLIDER * rng.gen::<f64>(),
+            })
+            .insert(Count { count: 0 });
     }
 
-//    let mut cnt = 0;
-//    for (_ent1, _position, _collider, _count) in query.iter() {
-//        cnt += 1;
-//    }
-//    println!("Ent Count: {}", cnt);
+    //    let mut cnt = 0;
+    //    for (_ent1, _position, _collider, _count) in query.iter() {
+    //        cnt += 1;
+    //    }
+    //    println!("Ent Count: {}", cnt);
 }
 
 fn update_position(mut query: Query<(&mut Position, &mut Velocity)>) {
@@ -162,7 +188,7 @@ fn update_position(mut query: Query<(&mut Position, &mut Velocity)>) {
     }
 }*/
 
-fn native(size : i32, collision_limit : i32) {
+fn native(size: i32, collision_limit: i32) {
     let mut ids = Vec::new();
     let mut pos = Vec::new();
     let mut vel = Vec::new();
@@ -171,11 +197,19 @@ fn native(size : i32, collision_limit : i32) {
 
     let mut rng = rand::thread_rng();
     for i in 0..size {
-        ids.push(i+2);
-        pos.push(Position{ x: MAX_POSITION * rng.gen::<f64>(), y: MAX_POSITION * rng.gen::<f64>() });
-        vel.push(Velocity{ x: MAX_SPEED * rng.gen::<f64>(), y: MAX_SPEED * rng.gen::<f64>() });
-        col.push(Collider{ radius: MAX_COLLIDER * rng.gen::<f64>() });
-        cnt.push(Count{ count: 0 });
+        ids.push(i + 2);
+        pos.push(Position {
+            x: MAX_POSITION * rng.gen::<f64>(),
+            y: MAX_POSITION * rng.gen::<f64>(),
+        });
+        vel.push(Velocity {
+            x: MAX_SPEED * rng.gen::<f64>(),
+            y: MAX_SPEED * rng.gen::<f64>(),
+        });
+        col.push(Collider {
+            radius: MAX_COLLIDER * rng.gen::<f64>(),
+        });
+        cnt.push(Count { count: 0 });
     }
 
     let fixed_time = 0.015;
@@ -228,22 +262,26 @@ fn native(size : i32, collision_limit : i32) {
         }
 
         let duration = start.elapsed();
-        println!("{} {:?}", iter_count, (duration.as_micros() as f64) / 1000000.0)
+        println!(
+            "{} {:?}",
+            iter_count,
+            (duration.as_micros() as f64) / 1000000.0
+        )
     }
 }
 
-fn native_split(size : i32, collision_limit : i32) {
+fn native_split(size: i32, collision_limit: i32) {
     let mut ids = Vec::new();
     let mut pos_x = Vec::new();
     let mut pos_y = Vec::new();
     let mut vel_x = Vec::new();
     let mut vel_y = Vec::new();
     let mut col = Vec::new();
-    let mut cnt : Vec<i32> = Vec::new();
+    let mut cnt: Vec<i32> = Vec::new();
 
     let mut rng = rand::thread_rng();
     for i in 0..size {
-        ids.push(i+2);
+        ids.push(i + 2);
         pos_x.push(MAX_POSITION * rng.gen::<f64>());
         pos_y.push(MAX_POSITION * rng.gen::<f64>());
         vel_x.push(MAX_SPEED * rng.gen::<f64>());
@@ -301,6 +339,10 @@ fn native_split(size : i32, collision_limit : i32) {
         }
 
         let duration = start.elapsed();
-        println!("{} {:?}", iter_count, (duration.as_micros() as f64) / 1000000.0)
+        println!(
+            "{} {:?}",
+            iter_count,
+            (duration.as_micros() as f64) / 1000000.0
+        )
     }
 }


### PR DESCRIPTION
Your video was very interesting!

I've been doing rust professionally for a few years, and wanted to try my hand at an implementation.

Besides some general usage of `std::ops` to clean up code reading, the only interesting change is instead of two loops over all entities, I do one loop over all and the second loop over only entities to the right.

Additionally, I created a single entity struct. In this case, I don't think SOA is useful.

I'm curious what performance differences you see on your hardware! I didn't know which values to use to test, but I'm seeing roughly at 4x speedup on my hardware